### PR TITLE
Add Transaction Logs: View Borrow and Return History from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Features Branch for Return Functionality
+### Features Branch for View Transaction Logs Functionality
 
 ### Run
 ```bash
@@ -15,6 +15,7 @@ java -cp "lib/*:out" app.Main
 4. Delete book
 5. Borrow book
 6. Return book
+7. View Transaction Logs
 0. Exit
 
 Choose option:
@@ -23,10 +24,12 @@ Choose option:
 
 ```
 Example usage:
-Choose option: 6
-Enter book ID to return: 2
-Enter user ID: 1
-📥 Book returned!
+Choose option: 7
+📖 Borrow Logs:
+ - [#1] Book ID: 2, User ID: 1, Borrowed: 2025-07-01 09:00:00
+
+📥 Return Logs:
+ - [#1] Book ID: 2, User ID: 1, Returned: 2025-07-01 09:05:00
 ```
 
 ## 🛠 Tech Stack
@@ -40,5 +43,4 @@ Enter user ID: 1
 ---
 
 ## 📌 Next Feature Branches
-* `feature/transactions` – Immutable transaction logs
 * `feature/unit-tests` – JUnit test coverage

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -6,6 +6,7 @@ import infra.SQLiteTransactionRepository;
 import usecase.BookService;
 import usecase.BorrowService;
 import usecase.ReturnService;
+import usecase.TransactionService;
 import data.UserRepository;
 import domain.Book;
 import domain.User;
@@ -23,7 +24,7 @@ public class Main {
         var bookService = new BookService(bookRepo);
         var borrowService = new BorrowService(transactionRepo, bookRepo);
         var returnService = new ReturnService(transactionRepo, bookRepo);
-
+        var transactionService = new TransactionService(new SQLiteTransactionRepository());
 
         Scanner scanner = new Scanner(System.in); // For user input
 
@@ -37,6 +38,7 @@ public class Main {
             System.out.println("4. Delete book");
             System.out.println("5. Borrow book");
             System.out.println("6. Return book");
+            System.out.println("7. View Transaction Logs");
             System.out.println("0. Exit");
             System.out.print("Choose option: ");
             String choice = scanner.nextLine();
@@ -89,7 +91,20 @@ public class Main {
                     boolean success = returnService.returnBook(bookId, userId);
                     System.out.println(success ? "📥 Book returned!" : "❌ Book is already available or doesn't exist.");
                 }
-
+                case "7" -> {
+                    // Return borrow and return logs
+                    System.out.println("📖 Borrow Logs:");
+                    for (var tx : transactionService.getBorrowLogs()) {
+                        System.out.println(" - [#" + tx.getId() + "] Book ID: " + tx.getBookId()
+                                + ", User ID: " + tx.getUserId() + ", Borrowed: " + tx.getDateBorrowed());
+                    }
+                
+                    System.out.println("\n📥 Return Logs:");
+                    for (var tx : transactionService.getReturnLogs()) {
+                        System.out.println(" - [#" + tx.getId() + "] Book ID: " + tx.getBookId()
+                                + ", User ID: " + tx.getUserId() + ", Returned: " + tx.getDateReturned());
+                    }
+                }
                 case "0" -> {
                     // Exit the program
                     System.out.println("👋 Exiting...");

--- a/src/data/TransactionRepository.java
+++ b/src/data/TransactionRepository.java
@@ -1,10 +1,13 @@
 package data;
 
 import domain.BorrowTransaction;
+import domain.ReturnTransaction;
 import java.util.List;
 
 public interface TransactionRepository {
     void recordBorrow(int bookId, int userId);
     void recordReturn(int bookId, int userId);
-    List<BorrowTransaction> getAllTransactions();
+    List<BorrowTransaction> getAllBorrowTransactions();
+    List<ReturnTransaction> getAllReturnTransactions();
+
 }

--- a/src/domain/BorrowTransaction.java
+++ b/src/domain/BorrowTransaction.java
@@ -13,5 +13,29 @@ public class BorrowTransaction {
         this.dateBorrowed = dateBorrowed;
     }
 
-    // Getters and toString()
+    public int getId() {
+        return id;
+    }
+
+    public int getBookId() {
+        return bookId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public String getDateBorrowed() {
+        return dateBorrowed;
+    }
+
+    @Override
+    public String toString() {
+        return "BorrowTransaction{" +
+                "id=" + id +
+                ", bookId=" + bookId +
+                ", userId=" + userId +
+                ", dateBorrowed='" + dateBorrowed + '\'' +
+                '}';
+    }
 }

--- a/src/domain/ReturnTransaction.java
+++ b/src/domain/ReturnTransaction.java
@@ -13,5 +13,29 @@ public class ReturnTransaction {
         this.dateReturned = dateReturned;
     }
 
-    // Getters and toString()
+    public int getId() {
+        return id;
+    }
+
+    public int getBookId() {
+        return bookId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public String getDateReturned() {
+        return dateReturned;
+    }
+
+    @Override
+    public String toString() {
+        return "ReturnTransaction{" +
+                "id=" + id +
+                ", bookId=" + bookId +
+                ", userId=" + userId +
+                ", dateReturned='" + dateReturned + '\'' +
+                '}';
+    }
 }

--- a/src/infra/SQLiteTransactionRepository.java
+++ b/src/infra/SQLiteTransactionRepository.java
@@ -2,6 +2,7 @@ package infra;
 
 import data.TransactionRepository;
 import domain.BorrowTransaction;
+import domain.ReturnTransaction;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -95,15 +96,14 @@ public class SQLiteTransactionRepository implements TransactionRepository {
             e.printStackTrace();
         }
     }
-
-
+    
     @Override
-    public List<BorrowTransaction> getAllTransactions() {
+    public List<BorrowTransaction> getAllBorrowTransactions() {
         List<BorrowTransaction> list = new ArrayList<>();
         try (Connection conn = DriverManager.getConnection(url);
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT * FROM borrow_transactions")) {
-
+    
             while (rs.next()) {
                 list.add(new BorrowTransaction(
                         rs.getInt("id"),
@@ -117,4 +117,26 @@ public class SQLiteTransactionRepository implements TransactionRepository {
         }
         return list;
     }
+    
+    @Override
+    public List<ReturnTransaction> getAllReturnTransactions() {
+        List<ReturnTransaction> list = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection(url);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT * FROM return_transactions")) {
+    
+            while (rs.next()) {
+                list.add(new ReturnTransaction(
+                        rs.getInt("id"),
+                        rs.getInt("book_id"),
+                        rs.getInt("user_id"),
+                        rs.getString("date_returned")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
 }

--- a/src/usecase/TransactionService.java
+++ b/src/usecase/TransactionService.java
@@ -1,0 +1,23 @@
+package usecase;
+
+import data.TransactionRepository;
+import domain.BorrowTransaction;
+import domain.ReturnTransaction;
+
+import java.util.List;
+
+public class TransactionService {
+    private final TransactionRepository repo;
+
+    public TransactionService(TransactionRepository repo) {
+        this.repo = repo;
+    }
+
+    public List<BorrowTransaction> getBorrowLogs() {
+        return repo.getAllBorrowTransactions();
+    }
+
+    public List<ReturnTransaction> getReturnLogs() {
+        return repo.getAllReturnTransactions();
+    }
+}


### PR DESCRIPTION
📊 This PR adds the ability to view all borrow and return transactions directly from the CLI.

✅ What's Included:
- Extended `TransactionRepository` with:
  - `getAllBorrowTransactions()`
  - `getAllReturnTransactions()`
- Implemented both methods in `SQLiteTransactionRepository`
- Created `TransactionService` to handle log retrieval
- Updated CLI (`Main.java`) with:
  - Option 7: View transaction logs
  - Prints all entries from both borrow and return tables in readable format

🧪 Sample Output:
Choose option: 7
📖 Borrow Logs:
 - [#1] Book ID: 2, User ID: 1, Borrowed: 2025-07-01 09:00:00

📥 Return Logs:
 - [#1] Book ID: 2, User ID: 1, Returned: 2025-07-01 09:05:00

🛠 This completes the transaction flow and sets up the system for read-only audit trails.
